### PR TITLE
Require dialog-polyfill only on component load

### DIFF
--- a/src/hyperdom-modal.js
+++ b/src/hyperdom-modal.js
@@ -2,7 +2,6 @@
 
 const hyperdom = require('hyperdom')
 const h = hyperdom.html
-const dialogPolyfill = require('dialog-polyfill')
 
 module.exports = class Modal {
   constructor({ showModal = false, onExit, rootClass = 'modal' }, content) {
@@ -14,6 +13,8 @@ module.exports = class Modal {
 
   onrender(element) {
     const isOpen = element.hasAttribute('open')
+
+    const dialogPolyfill = require('dialog-polyfill')
     dialogPolyfill.registerDialog(element)
 
     if (!isOpen && this._showModal) {


### PR DESCRIPTION
This fixes a bug where the polyfill is required outside of a normal browser DOM, resulting in `window is undefined` errors.