### PR TITLE
Use hyperdom binding instead of showModal boolean and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,28 @@ class DemoApp {
   constructor() {
     this._favourite = 'undecided'
     this._choosing = false
-    this._modal = new HyperdomModal(
+
+    this._modal1 = new HyperdomModal(
+      h(
+        '.modal-content',
+        h('h2.modal-heading', 'Hello!'),
+        h(
+          'button',
+          {
+            onclick: () => this._modal1.close()
+          },
+          'Goodbye!'
+        )
+      )
+    )
+
+    this._modal2 = new HyperdomModal(
       {
         openBinding: [this, '_choosing'],
-        options: { class: 'modal' }
+        onCancel: () => {
+          this._favourite = this._previousFavourite
+        },
+        dialogOptions: { class: 'modal' }
       },
       h(
         '.modal-content',
@@ -50,17 +68,14 @@ class DemoApp {
         h(
           'button',
           {
-            onclick: () => this._modal.toggle()
+            onclick: () => this._modal2.close()
           },
           'Confirm'
         ),
         h(
           'button',
           {
-            onclick: () => {
-              this._favourite = this._previousFavourite
-              this._modal.toggle()
-            }
+            onclick: () => this._modal2.cancel()
           },
           'Cancel'
         )
@@ -73,19 +88,30 @@ class DemoApp {
       'main.container',
       h(
         '.text-center',
+        h(
+          'button',
+          {
+            onclick: () => this._modal1.open()
+          },
+          'Greet me'
+        )
+      ),
+      h(
+        '.text-center',
         h('p', 'Your favourite animal is: ', this._favourite),
         h(
           'button',
           {
             onclick: () => {
               this._previousFavourite = this._favourite
-              this._modal.toggle()
+              this._modal2.open()
             }
           },
           'Choose an animal'
         )
       ),
-      this._modal
+      this._modal1,
+      this._modal2
     )
   }
 }
@@ -101,10 +127,11 @@ You can add styles to override the defaults and style the content passed in to y
 
 ## Options
 
-|     Name      |   Type    | Default | Description                                                                       |
-| :-----------: | :-------: | :-----: | :-------------------------------------------------------------------------------- |
-| `openBinding` | `binding` | `none`  | A hyperdom binding that determines whether the modal window is open               |
-|   `options`   | `object`  | `none`  | Any options such as attributes or event handlers passed to the `<dialog>` element |
+|      Name       |    Type    | Default | Description                                                                         |
+| :-------------: | :--------: | :-----: | :---------------------------------------------------------------------------------- |
+|  `openBinding`  | `binding`  | `none`  | A hyperdom binding that determines whether the modal window is open                 |
+| `dialogOptions` |  `object`  | `none`  | Any options such as attributes or event handlers passed to the `<dialog>` element   |
+|   `onCancel`    | `function` | `none`  | A function that is called when the modal dialog is closed e.g. using the escape key |
 
 ## More About `<dialog>`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ class DemoApp {
     this._choosing = false
     this._modal = new HyperdomModal(
       {
-        openBinding: [this, '_choosing']
+        openBinding: [this, '_choosing'],
+        options: { class: 'modal' }
       },
       h(
         '.modal-content',
@@ -100,10 +101,10 @@ You can add styles to override the defaults and style the content passed in to y
 
 ## Options
 
-|     Name      |   Type    |  Default  | Description                                                         |
-| :-----------: | :-------: | :-------: | :------------------------------------------------------------------ |
-| `openBinding` | `binding` |  `none`   | A hyperdom binding that determines whether the modal window is open |
-|  `rootClass`  | `String`  | `'modal'` | Override the default class on the root modal element                |
+|     Name      |   Type    | Default | Description                                                                       |
+| :-----------: | :-------: | :-----: | :-------------------------------------------------------------------------------- |
+| `openBinding` | `binding` | `none`  | A hyperdom binding that determines whether the modal window is open               |
+|   `options`   | `object`  | `none`  | Any options such as attributes or event handlers passed to the `<dialog>` element |
 
 ## More About `<dialog>`
 

--- a/README.md
+++ b/README.md
@@ -24,54 +24,72 @@ const hyperdom = require('hyperdom')
 const h = hyperdom.html
 const HyperdomModal = require('hyperdom-modal')
 
-class YourApp {
+class DemoApp {
   constructor() {
-    this.modalActive = false
-  }
-
-  activateModal() {
-    this.modalActive = true
-  }
-
-  deactivateModal() {
-    this.modalActive = false
-  }
-
-  render() {
-    return h(
-      'div',
+    this._favourite = 'undecided'
+    this._choosing = false
+    this._modal = new HyperdomModal(
+      {
+        openBinding: [this, '_choosing']
+      },
       h(
-        'button',
-        {
-          type: 'button',
-          onclick: () => this.activateModal()
-        },
-        'Open Modal'
-      ),
-      new HyperdomModal(
-        {
-          showModal: this.modalActive,
-          onExit: this.deactivateModal
-        },
+        '.modal-content',
+        h('h2.modal-heading', 'Choose your favourite!'),
+        h('p', 'What is your favourite animal?'),
         h(
-          'div',
-          h('h2', 'Modal Heading'),
-          h('p', 'This is modal content.'),
+          'p',
           h(
-            'button',
-            {
-              type: 'button',
-              onclick: () => this.deactivateModal()
-            },
-            'Close'
+            'select',
+            { binding: [this, '_favourite'] },
+            h('option', 'undecided'),
+            h('option', 'cat'),
+            h('option', 'dog')
           )
+        ),
+        h(
+          'button',
+          {
+            onclick: () => this._modal.toggle()
+          },
+          'Confirm'
+        ),
+        h(
+          'button',
+          {
+            onclick: () => {
+              this._favourite = this._previousFavourite
+              this._modal.toggle()
+            }
+          },
+          'Cancel'
         )
       )
     )
   }
+
+  render() {
+    return h(
+      'main.container',
+      h(
+        '.text-center',
+        h('p', 'Your favourite animal is: ', this._favourite),
+        h(
+          'button',
+          {
+            onclick: () => {
+              this._previousFavourite = this._favourite
+              this._modal.toggle()
+            }
+          },
+          'Choose an animal'
+        )
+      ),
+      this._modal
+    )
+  }
 }
 
-hyperdom.append(document.getElementById('root'), new YourApp())
+hyperdom.append(document.getElementById('root'), new DemoApp())
 ```
 
 ### CSS
@@ -82,11 +100,10 @@ You can add styles to override the defaults and style the content passed in to y
 
 ## Options
 
-|    Name     |    Type    |   Default   | Description                                          |
-| :---------: | :--------: | :---------: | :--------------------------------------------------- |
-| `showModal` | `Boolean`  |   `false`   | Trigger the modal displaying on the page             |
-|  `onExit`   | `Function` | `undefined` | Function to call when user closes modal              |
-| `rootClass` |  `String`  |  `'modal'`  | Override the default class on the root modal element |
+|     Name      |   Type    |  Default  | Description                                                         |
+| :-----------: | :-------: | :-------: | :------------------------------------------------------------------ |
+| `openBinding` | `binding` |  `none`   | A hyperdom binding that determines whether the modal window is open |
+|  `rootClass`  | `String`  | `'modal'` | Override the default class on the root modal element                |
 
 ## More About `<dialog>`
 

--- a/demo/css/base.css
+++ b/demo/css/base.css
@@ -15,18 +15,18 @@ html {
   padding: 0 20px;
 }
 
-.button {
+button {
   background: transparent;
   border: 1px solid #444;
   color: #444;
   display: inline-block;
-  margin: 0;
+  margin: 5px;
   padding: 0.4em 0.75em;
   text-align: center;
   user-select: none;
 }
 
-.button:hover {
+button:hover {
   cursor: pointer;
 }
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -6,10 +6,28 @@ class DemoApp {
   constructor() {
     this._favourite = 'undecided'
     this._choosing = false
-    this._modal = new HyperdomModal(
+
+    this._modal1 = new HyperdomModal(
+      h(
+        '.modal-content',
+        h('h2.modal-heading', 'Hello!'),
+        h(
+          'button',
+          {
+            onclick: () => this._modal1.close()
+          },
+          'Goodbye!'
+        )
+      )
+    )
+
+    this._modal2 = new HyperdomModal(
       {
         openBinding: [this, '_choosing'],
-        options: { class: 'modal' }
+        onCancel: () => {
+          this._favourite = this._previousFavourite
+        },
+        dialogOptions: { class: 'modal' }
       },
       h(
         '.modal-content',
@@ -28,17 +46,14 @@ class DemoApp {
         h(
           'button',
           {
-            onclick: () => this._modal.toggle()
+            onclick: () => this._modal2.close()
           },
           'Confirm'
         ),
         h(
           'button',
           {
-            onclick: () => {
-              this._favourite = this._previousFavourite
-              this._modal.toggle()
-            }
+            onclick: () => this._modal2.cancel()
           },
           'Cancel'
         )
@@ -60,19 +75,30 @@ class DemoApp {
       ),
       h(
         '.text-center',
+        h(
+          'button',
+          {
+            onclick: () => this._modal1.open()
+          },
+          'Greet me'
+        )
+      ),
+      h(
+        '.text-center',
         h('p', 'Your favourite animal is: ', this._favourite),
         h(
           'button',
           {
             onclick: () => {
               this._previousFavourite = this._favourite
-              this._modal.toggle()
+              this._modal2.open()
             }
           },
           'Choose an animal'
         )
       ),
-      this._modal
+      this._modal1,
+      this._modal2
     )
   }
 }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -8,7 +8,8 @@ class DemoApp {
     this._choosing = false
     this._modal = new HyperdomModal(
       {
-        openBinding: [this, '_choosing']
+        openBinding: [this, '_choosing'],
+        options: { class: 'modal' }
       },
       h(
         '.modal-content',

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4,15 +4,45 @@ const HyperdomModal = require('../src/hyperdom-modal')
 
 class DemoApp {
   constructor() {
-    this.modalActive = false
-  }
-
-  activateModal() {
-    this.modalActive = true
-  }
-
-  deactivateModal() {
-    this.modalActive = false
+    this._favourite = 'undecided'
+    this._choosing = false
+    this._modal = new HyperdomModal(
+      {
+        openBinding: [this, '_choosing']
+      },
+      h(
+        '.modal-content',
+        h('h2.modal-heading', 'Choose your favourite!'),
+        h('p', 'What is your favourite animal?'),
+        h(
+          'p',
+          h(
+            'select',
+            { binding: [this, '_favourite'] },
+            h('option', 'undecided'),
+            h('option', 'cat'),
+            h('option', 'dog')
+          )
+        ),
+        h(
+          'button',
+          {
+            onclick: () => this._modal.toggle()
+          },
+          'Confirm'
+        ),
+        h(
+          'button',
+          {
+            onclick: () => {
+              this._favourite = this._previousFavourite
+              this._modal.toggle()
+            }
+          },
+          'Cancel'
+        )
+      )
+    )
   }
 
   render() {
@@ -29,34 +59,19 @@ class DemoApp {
       ),
       h(
         '.text-center',
+        h('p', 'Your favourite animal is: ', this._favourite),
         h(
-          'button.button',
+          'button',
           {
-            type: 'button',
-            onclick: () => this.activateModal()
+            onclick: () => {
+              this._previousFavourite = this._favourite
+              this._modal.toggle()
+            }
           },
-          'Open Modal'
+          'Choose an animal'
         )
       ),
-      new HyperdomModal(
-        {
-          showModal: this.modalActive,
-          onExit: this.deactivateModal
-        },
-        h(
-          '.modal-content',
-          h('h2.modal-heading', 'Modal Heading'),
-          h('p', 'This is a modal with some custom styling.'),
-          h(
-            'button.button',
-            {
-              type: 'button',
-              onclick: () => this.deactivateModal()
-            },
-            'Close Modal'
-          )
-        )
-      )
+      this._modal
     )
   }
 }

--- a/src/hyperdom-modal.js
+++ b/src/hyperdom-modal.js
@@ -4,39 +4,38 @@ const hyperdom = require('hyperdom')
 const h = hyperdom.html
 
 module.exports = class Modal {
-  constructor({ showModal = false, onExit, rootClass = 'modal' }, content) {
-    this._showModal = showModal
-    this._onExit = onExit
-    this._rootClass = rootClass
+  constructor({ openBinding, options }, content) {
+    this._openBinding = hyperdom.binding(openBinding)
+    this._options = options
     this._content = content
   }
 
-  onrender(element) {
-    const isOpen = element.hasAttribute('open')
+  toggle() {
+    this._openBinding.set(!this._openBinding.get())
+  }
 
+  onrender(element) {
     const dialogPolyfill = require('dialog-polyfill')
     dialogPolyfill.registerDialog(element)
-
-    if (!isOpen && this._showModal) {
-      element.showModal()
-    }
-    if (isOpen && !this._showModal) {
-      element.close()
-    }
-
-    element.addEventListener('cancel', () => {
-      this._onExit()
-    })
-
-    element.addEventListener('click', event => {
-      if (event.target === element && element.hasAttribute('open')) {
-        element.close()
-        this._onExit()
-      }
-    })
   }
 
   render() {
-    return h('dialog', { class: this._rootClass }, this._content)
+    const open = this._openBinding.get()
+    const options = open
+      ? optionsWithOpenAttribute(this._options)
+      : this._options
+    return h('dialog', options, this._content)
   }
+}
+
+function optionsWithOpenAttribute(options) {
+  const merged = {}
+  for (const key in options) {
+    if (Object.prototype.hasOwnProperty.apply(options, key)) {
+      merged[key] = options[key]
+    }
+  }
+  merged.attributes = merged.attributes || {}
+  merged.attributes.open = true
+  return merged
 }

--- a/src/hyperdom-modal.js
+++ b/src/hyperdom-modal.js
@@ -4,28 +4,55 @@ const hyperdom = require('hyperdom')
 const h = hyperdom.html
 
 module.exports = class Modal {
-  constructor({ openBinding, options }, content) {
-    this._openBinding = hyperdom.binding(openBinding)
-    this._options = options
-    this._content = content
+  constructor() {
+    const firstArgumentIsOptions =
+      typeof arguments[0] === 'object' &&
+      typeof arguments[0].tagName === 'undefined'
+    const { openBinding, dialogOptions, onCancel } = firstArgumentIsOptions
+      ? arguments[0]
+      : {}
+    this._openBinding = hyperdom.binding(openBinding || [this, '_binding'])
+    this._dialogOptions = dialogOptions
+    this._onCancel = onCancel || (() => {})
+    this._content = [].slice.call(arguments, firstArgumentIsOptions ? 1 : 0)
+
+    this._closeHandler = () => {
+      if (this._isProgrammaticClose) {
+        delete this._isProgrammaticClose
+      } else {
+        this._onCancel()
+        this._isOpen = false
+        this._openBinding.set(false)
+        this.refreshImmediately()
+      }
+    }
   }
 
-  toggle() {
-    this._openBinding.set(!this._openBinding.get())
+  open() {
+    this._openBinding.set(true)
+  }
+
+  close() {
+    this._isProgrammaticClose = true
+    this._openBinding.set(false)
+  }
+
+  cancel() {
+    this._isProgrammaticClose = true
+    this._onCancel()
+    this._openBinding.set(false)
   }
 
   onrender(element) {
     const dialogPolyfill = require('dialog-polyfill')
     dialogPolyfill.registerDialog(element)
-    showModalOrClose(this, element)
-  }
-
-  onupdate(element) {
+    element.removeEventListener('close', this._closeHandler)
+    element.addEventListener('close', this._closeHandler)
     showModalOrClose(this, element)
   }
 
   render() {
-    return h('dialog', this._options, this._content)
+    return h('dialog', this._dialogOptions, this._content)
   }
 }
 

--- a/src/hyperdom-modal.js
+++ b/src/hyperdom-modal.js
@@ -17,25 +17,24 @@ module.exports = class Modal {
   onrender(element) {
     const dialogPolyfill = require('dialog-polyfill')
     dialogPolyfill.registerDialog(element)
+    showModalOrClose(this, element)
+  }
+
+  onupdate(element) {
+    showModalOrClose(this, element)
   }
 
   render() {
-    const open = this._openBinding.get()
-    const options = open
-      ? optionsWithOpenAttribute(this._options)
-      : this._options
-    return h('dialog', options, this._content)
+    return h('dialog', this._options, this._content)
   }
 }
 
-function optionsWithOpenAttribute(options) {
-  const merged = {}
-  for (const key in options) {
-    if (Object.prototype.hasOwnProperty.apply(options, key)) {
-      merged[key] = options[key]
-    }
+function showModalOrClose(modal, element) {
+  const wasOpen = modal._isOpen
+  modal._isOpen = modal._openBinding.get()
+  if (modal._isOpen && !wasOpen) {
+    element.showModal()
+  } else if (wasOpen && !modal._isOpen) {
+    element.close()
   }
-  merged.attributes = merged.attributes || {}
-  merged.attributes.open = true
-  return merged
 }


### PR DESCRIPTION
In most cases it's not ideal to introduce a boolean variable tracking whether or not a modal is open. The advantage of hyperdom components is that they can keep this kind of "temporary view state" out of your view model. Since hyperdom-modal is a component, the simplest case can look like this:

```js
this._modal = new HyperdomModal(
  h(
    'div',
    'modal content...',
    h(
      'button',
      {
        onclick: () => this._modal.close()
      },
      'Close modal'
    )
  )
)
```

Furthermore, when we really want a variable tracking the "open-ness", then the idiomatic way to do that in hyperdom is to use a two way binding. So this changes the constructor arguments such that a **binding** is passed in, instead of the `showModal` boolean we previously passed.

In practice this means anything that triggers a re-render after the modal is opened (such as a promise resolving, or user input _inside_ the modal) does not _reset_ the open-ness of the modal. 

I've made the demo a bit more complicated because I thought it would help to demonstrate how you might achieve a user interaction inside the modal, without closing the modal, that could eventually be cancelled. This seems like a pretty typical use case beyond the basic "alert" that we had in the demo before.

I also changed the API to allow _any_ options to be passed through to the underlying `<dialog>`, not just the class name.

Finally, I renamed `onExit` to `onCancel`, since I think of pressing the escape key as equivalent to pressing the "cancel" button, if there is one.