### PR TITLE
Improve outside click code

### DIFF
--- a/src/hyperdom-modal.js
+++ b/src/hyperdom-modal.js
@@ -28,6 +28,12 @@ module.exports = class Modal {
     }
   }
 
+  outsideClickHandler(event, element) {
+    if (event.target === element && this._isOpen) {
+      element.close()
+    }
+  }
+
   open() {
     this._openBinding.set(true)
   }
@@ -50,10 +56,11 @@ module.exports = class Modal {
     element.addEventListener('close', this._closeHandler)
     showModalOrClose(this, element)
 
+    element.removeEventListener('click', event => {
+      this.outsideClickHandler(event, element)
+    })
     element.addEventListener('click', event => {
-      if (event.target === element && element.hasAttribute('open')) {
-        element.close()
-      }
+      this.outsideClickHandler(event, element)
     })
   }
 

--- a/src/hyperdom-modal.js
+++ b/src/hyperdom-modal.js
@@ -55,10 +55,6 @@ module.exports = class Modal {
     element.removeEventListener('close', this._closeHandler)
     element.addEventListener('close', this._closeHandler)
     showModalOrClose(this, element)
-
-    element.removeEventListener('click', event => {
-      this.outsideClickHandler(event, element)
-    })
     element.addEventListener('click', event => {
       this.outsideClickHandler(event, element)
     })


### PR DESCRIPTION
Addresses https://github.com/featurist/hyperdom-modal/pull/3#pullrequestreview-116157697

- Determine open-ness from `this._isOpen` instead of `open` attribute
- ~~Remove click outside event listener in same way as close listener~~